### PR TITLE
adds nix flake that should work for linux and macOS systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1685561376,
+        "narHash": "sha256-uIcJdaovXr55FJdmvR6yIN6IWoOL4amBj56e/T2KhgM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bc3ec5eaa759d58e9fb1bdc9cfe94f74d0331b31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "A very basic flake for gpt-cli";
+  nixConfig.bash-prompt = "[gpt-cli-development-env]$ ";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  outputs = { self, nixpkgs }: let
+    # The set of systems to provide outputs for
+    allSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+    # A function that provides a system-specific Nixpkgs for the desired systems
+    forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f { pkgs = import nixpkgs { inherit system; }; });
+  in {
+    packages = forAllSystems ({ pkgs }: {
+      default = pkgs.mkShell {
+        buildInputs = [ pkgs.jq pkgs.sqlite ];
+      };
+    });
+  };
+}


### PR DESCRIPTION
From ChatGPT:

A Nix flake is a new feature introduced in Nix 2.4 that allows for the definition and composition of Nix packages and configurations in a more modular and composable way. 

A Nix flake is a self-contained unit that can contain Nix expressions, such as package definitions, configuration files, and build instructions. Flakes provide a declarative way to specify dependencies between packages and configurations, making it easier to create and manage reproducible development environments and deployments.

A Nix flake is defined in a `flake.nix` file, which contains the top-level definition of the flake, including its inputs, outputs, and any other metadata. The inputs and outputs of a flake are defined using attributes, making it easy to reference and reuse them in other flakes.

One of the main benefits of using Nix flakes is the ability to use them with the `nix flake` command, which allows for more efficient and parallelized builds, as well as improved caching and reproducibility.

<hr>

Added this for nix users; should work on macOS and linux
